### PR TITLE
Esp8266 tidyup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/olliw42/stm32ll-lib.git
 [submodule "mLRS/modules/sx12xx-lib"]
 	path = mLRS/modules/sx12xx-lib
-	url = https://github.com/olliw42/sx12xx-lib.git
+	url = https://github.com/tmcadam/sx12xx-lib.git
 [submodule "tools/st-drivers/stm32f1xx_hal_driver"]
 	path = tools/st-drivers/stm32f1xx_hal_driver
 	url = https://github.com/STMicroelectronics/stm32f1xx_hal_driver.git

--- a/mLRS/Common/esp-lib/esp-spi.h
+++ b/mLRS/Common/esp-lib/esp-spi.h
@@ -11,8 +11,6 @@
 
 #include <SPI.h>
 
-SPIClass* spi = NULL;
-
 //-- select functions
 
 #ifndef SPI_SELECT_PRE_DELAY
@@ -33,7 +31,6 @@ SPIClass* spi = NULL;
 
 static inline void spi_select(void)
 {
-  spi->beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
   SPI_SELECT_PRE_DELAY;
   digitalWrite(SPI_CS_IO, LOW); // CS = low
   SPI_SELECT_POST_DELAY;
@@ -45,24 +42,16 @@ static inline void spi_deselect(void)
   SPI_DESELECT_PRE_DELAY;
   digitalWrite(SPI_CS_IO, HIGH); // CS = high
   SPI_DESELECT_POST_DELAY;
-  spi->endTransaction();
 }
 
 void spi_init(void)
 {
-#if defined(ESP32) 
-  spi = new SPIClass(HSPI);
-#elif defined(ESP8266)
-  spi = new SPIClass();
-#endif
-
-#if defined(ESP32)
-  spi->begin(HSPI_SCLK, HSPI_MISO, HSPI_MOSI, SPI_CS_IO);
-#elif defined(ESP8266)
-  spi->begin();
-#endif
-
   pinMode(SPI_CS_IO, OUTPUT);
+
+  SPI.begin();
+  SPI.setFrequency(SPI_FREQUENCY);
+  SPI.setBitOrder(MSBFIRST);
+  SPI.setDataMode(SPI_MODE0);
 }
 
 //-- transmit, transfer, read, write functions
@@ -70,13 +59,13 @@ void spi_init(void)
 // to utilize ESP SPI Buffer
 static inline IRAM_ATTR void spi_transferbytes(uint8_t* dataout, uint8_t* datain, uint8_t len)
 {
-  spi->transferBytes(dataout, datain, len);
+  SPI.transferBytes(dataout, datain, len);
 }
 
 // is blocking
 uint8_t spi_transmitchar(uint8_t c)
 {
-  return spi->transfer(c);
+  return SPI.transfer(c);
 }
 
 // is blocking

--- a/mLRS/Common/esp-lib/esp-spi.h
+++ b/mLRS/Common/esp-lib/esp-spi.h
@@ -67,6 +67,12 @@ void spi_init(void)
 
 //-- transmit, transfer, read, write functions
 
+// to utilize ESP SPI Buffer
+static inline IRAM_ATTR void spi_transferbytes(uint8_t* dataout, uint8_t* datain, uint8_t len)
+{
+  spi->transferBytes(dataout, datain, len);
+}
+
 // is blocking
 uint8_t spi_transmitchar(uint8_t c)
 {

--- a/mLRS/Common/hal/device_conf.h
+++ b/mLRS/Common/hal/device_conf.h
@@ -311,6 +311,13 @@ The default selection of frequency bands can be overruled by feature defines.
   #define FREQUENCY_BAND_915_MHZ_FCC
 #endif
 
+#ifdef RX_BAYCKRC_900_PA_ESP8285
+  #define DEVICE_NAME "BAYKRC 900 PA"
+  #define DEVICE_IS_RECEIVER
+  #define DEVICE_HAS_SX127x
+  #define FREQUENCY_BAND_915_MHZ_FCC
+#endif
+
 #ifdef RX_GENERIC_2400_ESP8285
   #define DEVICE_NAME "GENERIC 2400"
   #define DEVICE_IS_RECEIVER

--- a/mLRS/Common/hal/esp-glue.h
+++ b/mLRS/Common/hal/esp-glue.h
@@ -16,3 +16,9 @@ void hal_init(void)
 {
     // nothing to do
 }
+
+// setup(), loop() streamlining between Arduino/STM code
+uint8_t restart_controller = 0;
+void setup() {}
+void main_loop(void);
+void loop() { main_loop(); }

--- a/mLRS/Common/hal/esp-glue.h
+++ b/mLRS/Common/hal/esp-glue.h
@@ -22,3 +22,15 @@ uint8_t restart_controller = 0;
 void setup() {}
 void main_loop(void);
 void loop() { main_loop(); }
+
+#define INITCONTROLLER_ONCE \
+    if(restart_controller <= 1){ \
+    if(restart_controller == 0){
+#define RESTARTCONTROLLER \
+    }
+#define INITCONTROLLER_END \
+    restart_controller = UINT8_MAX; \
+    }
+#define GOTO_RESTARTCONTROLLER \
+    restart_controller = 1; \
+    return;

--- a/mLRS/Common/hal/esp/rx-hal-bayckrc-900-pa-esp8285.h
+++ b/mLRS/Common/hal/esp/rx-hal-bayckrc-900-pa-esp8285.h
@@ -1,0 +1,117 @@
+//*******************************************************
+// Copyright (c) MLRS project
+// GPL3
+// https://www.gnu.org/licenses/gpl-3.0.de.html
+// OlliW @ www.olliw.eu
+//*******************************************************
+// hal
+//********************************************************
+
+//-------------------------------------------------------
+// BAYCKRC 900 PA RX
+//-------------------------------------------------------
+
+#define DEVICE_HAS_SINGLE_LED
+//#define DEVICE_HAS_NO_DEBUG
+#define DEVICE_HAS_SERIAL_OR_DEBUG
+
+//-- Timers, Timing, EEPROM, and such stuff
+
+#define DELAY_USE_DWT
+
+#define SYSTICK_TIMESTEP          1000
+#define SYSTICK_DELAY_MS(x)       (uint16_t)(((uint32_t)(x)*(uint32_t)1000)/SYSTICK_TIMESTEP)
+
+#define EE_START_PAGE             0 // 128 kB flash, 2 kB page
+
+#define MICROS_TIMx               TIM15
+
+//-- UARTS
+// UARTB = serial port
+// UART = output port, SBus or whatever
+// UARTC = debug port
+
+#define UARTB_USE_SERIAL
+#define UARTB_BAUD                  RX_SERIAL_BAUDRATE
+#define UARTB_USE_TX
+#define UARTB_TXBUFSIZE             RX_SERIAL_TXBUFSIZE // 1024 // 512
+#define UARTB_USE_TX_ISR
+#define UARTB_USE_RX
+#define UARTB_RXBUFSIZE             RX_SERIAL_RXBUFSIZE // 1024 // 512
+
+#define UARTC_USE_SERIAL
+#define UARTC_BAUD                  115200
+
+
+//-- SX1: SX12xx & SPI
+#define SPI_CS_IO                 15
+#define SPI_FREQUENCY             10000000L
+#define SX_RESET                  2
+#define SX_DIO0                   4
+#define SX_DIO1                   5
+
+IRQHANDLER(void IRAM_ATTR SX_DIO_EXTI_IRQHandler(void);)
+
+void sx_init_gpio(void)
+{
+    pinMode(SX_RESET, OUTPUT);
+    pinMode(SX_DIO0, INPUT);
+
+    digitalWrite(SX_RESET, HIGH);
+} 
+
+void sx_dio_enable_exti_isr(void)
+{
+    attachInterrupt(SX_DIO0, SX_DIO_EXTI_IRQHandler, RISING);
+}
+
+void sx_amp_transmit(void) {}
+void sx_amp_receive(void) {}
+void sx_dio_init_exti_isroff(void) {}
+void sx_dio_exti_isr_clearflag(void) {}
+
+
+//-- Button
+#define BUTTON                    0
+
+void button_init(void)
+{
+    pinMode(BUTTON, INPUT_PULLUP);
+}
+
+bool button_pressed(void)
+{
+    return (digitalRead(BUTTON) == HIGH) ? false : true;
+}
+
+
+//-- LEDs
+#define LED_RED                   16
+
+void leds_init(void)
+{
+    pinMode(LED_RED, OUTPUT);
+    digitalWrite(LED_RED, LOW);// LED_RED_OFF
+}
+
+void led_red_off(void) { gpio_low(LED_RED); }
+void led_red_on(void) { gpio_high(LED_RED); }
+void led_red_toggle(void) { gpio_toggle(LED_RED); }
+
+void led_green_off(void) {}
+void led_green_on(void) {}
+void led_green_toggle(void) {}
+
+
+//-- POWER
+#define POWER_GAIN_DBM            13 // gain of a PA stage if present
+#define POWER_SX1276_MAX_DBM      SX1276_OUTPUT_POWER_MAX // maximum allowed sx power
+#define POWER_USE_DEFAULT_RFPOWER_CALC
+
+#define RFPOWER_DEFAULT           0 // index into rfpower_list array
+
+const rfpower_t rfpower_list[] = {
+    { .dbm = POWER_20_DBM, .mW = 100 },
+    { .dbm = POWER_24_DBM, .mW = 250 },
+    { .dbm = POWER_27_DBM, .mW = 500 },
+};

--- a/mLRS/Common/hal/esp/rx-hal-bayckrc-900-pa-esp8285.h
+++ b/mLRS/Common/hal/esp/rx-hal-bayckrc-900-pa-esp8285.h
@@ -12,8 +12,8 @@
 //-------------------------------------------------------
 
 #define DEVICE_HAS_SINGLE_LED
-//#define DEVICE_HAS_NO_DEBUG
-#define DEVICE_HAS_SERIAL_OR_DEBUG
+#define DEVICE_HAS_NO_DEBUG
+//#define DEVICE_HAS_SERIAL_OR_DEBUG
 
 //-- Timers, Timing, EEPROM, and such stuff
 

--- a/mLRS/Common/hal/glue.h
+++ b/mLRS/Common/hal/glue.h
@@ -134,3 +134,15 @@ void hal_init(void)
 uint8_t restart_controller = 0;
 void main_loop(void);
 int main_main(void) { while(1) main_loop(); }
+
+#define INITCONTROLLER_ONCE \
+    if(restart_controller <= 1){ \
+    if(restart_controller == 0){
+#define RESTARTCONTROLLER \
+    }
+#define INITCONTROLLER_END \
+    restart_controller = UINT8_MAX; \
+    }
+#define GOTO_RESTARTCONTROLLER \
+    restart_controller = 1; \
+    return;

--- a/mLRS/Common/hal/glue.h
+++ b/mLRS/Common/hal/glue.h
@@ -129,3 +129,8 @@ void hal_init(void)
 
 
 #define IRAM_ATTR
+
+// setup(), loop() streamlining between Arduino/STM code
+uint8_t restart_controller = 0;
+void main_loop(void);
+int main_main(void) { while(1) main_loop(); }

--- a/mLRS/Common/hal/hal.h
+++ b/mLRS/Common/hal/hal.h
@@ -220,6 +220,10 @@ Note: Some "high-level" features are set for each device in the device_conf.h fi
 #include "esp/rx-hal-generic-900-esp8285.h"
 #endif
 
+#ifdef RX_BAYCKRC_900_PA_ESP8285
+#include "esp/rx-hal-bayckrc-900-pa-esp8285.h"
+#endif
+
 //-- ESP 2.4 GHz Devices
 
 #ifdef RX_GENERIC_2400_ESP8285

--- a/mLRS/Common/sx-drivers/sx127x_driver.h
+++ b/mLRS/Common/sx-drivers/sx127x_driver.h
@@ -316,6 +316,11 @@ class Sx127xDriver : public Sx127xDriverCommon
         *bytein = spi_transmitchar(*byteout);
     }
 
+    void SpiTransferBytes(uint8_t* byteout, uint8_t* bytein, uint8_t len) override
+    {
+        spi_transferbytes(byteout, bytein, len);  // stm32-ll calls this spi_transfer
+    }
+
     //-- RF power interface
 
     void RfPowerCalc(int8_t power_dbm, uint8_t* sx_power, int8_t* actual_power_dbm) override

--- a/mLRS/CommonRx/mlrs-rx.cpp
+++ b/mLRS/CommonRx/mlrs-rx.cpp
@@ -896,9 +896,6 @@ dbg.puts(s8toBCD_s(stats.last_rssi2));*/
         sx.SetToIdle();
         sx2.SetToIdle();
         leds.SetToParamStore();
-#ifdef ESP8266
-        rxclock.disable_isr();
-#endif
         setup_store_to_EEPROM();
 #if defined(ESP8266) || defined(ESP32)
         esp_setup(); //call reset

--- a/mLRS/CommonRx/mlrs-rx.cpp
+++ b/mLRS/CommonRx/mlrs-rx.cpp
@@ -503,12 +503,11 @@ void main_loop(void)
 #ifdef BOARD_TEST_H
     main_test();
 #endif
-if(restart_controller <= 1){//init
-if(restart_controller == 0){//init once
+INITCONTROLLER_ONCE
 
     stack_check_init();
 
-}//end of init once
+RESTARTCONTROLLER
 
     init_hw();
     DBG_MAIN(dbg.puts("\n\nDBG: Init complete\n"));
@@ -558,8 +557,7 @@ if(restart_controller == 0){//init once
 
     DBG_MAIN(dbg.puts("DBG: Starting loop\n"));
 
-restart_controller = UINT8_MAX;
-}//end of init
+INITCONTROLLER_END
 
     //-- SysTask handling
 
@@ -888,8 +886,7 @@ dbg.puts(s8toBCD_s(stats.last_rssi2));*/
         sx2.SetToIdle();
         leds.SetToParamStore();
         setup_store_to_EEPROM();
-        restart_controller = 1;
-        return;
+        GOTO_RESTARTCONTROLLER;
     }
 
 }//end of loop

--- a/mLRS/CommonRx/mlrs-rx.cpp
+++ b/mLRS/CommonRx/mlrs-rx.cpp
@@ -498,19 +498,18 @@ static inline bool connected(void)
 }
 
 
-#if defined(ESP8266) || defined(ESP32)
-void esp_setup()
-#else
-int main_main(void)
-#endif
+void main_loop(void)
 {
 #ifdef BOARD_TEST_H
     main_test();
 #endif
+if(restart_controller <= 1){//init
+if(restart_controller == 0){//init once
+
     stack_check_init();
-#if !defined(ESP8266) && !defined(ESP32)
-RESTARTCONTROLLER:
-#endif
+
+}//end of init once
+
     init_hw();
     DBG_MAIN(dbg.puts("\n\nDBG: Init complete\n"));
 
@@ -559,13 +558,9 @@ RESTARTCONTROLLER:
 
     DBG_MAIN(dbg.puts("DBG: Starting loop\n"));
 
-#if defined(ESP8266) || defined(ESP32)
-}//end of setup
-void loop() 
-{
-#else    
-  while (1) {
-#endif
+restart_controller = UINT8_MAX;
+}//end of init
+
     //-- SysTask handling
 
     if (doSysTask) {
@@ -853,11 +848,7 @@ dbg.puts(s8toBCD_s(stats.last_rssi2));*/
         doPostReceive2_cnt = 5; // postpone this few loops, to allow link_state changes to be handled
     }//end of if(doPostReceive)
 
-#if defined(ESP8266) || defined(ESP32)
     if (link_state != link_state_before) return; // link state has changed, so process immediately
-#else
-    if (link_state != link_state_before) continue; // link state has changed, so process immediately
-#endif    
 
     //-- Update channels, Out handling, etc
 
@@ -897,19 +888,9 @@ dbg.puts(s8toBCD_s(stats.last_rssi2));*/
         sx2.SetToIdle();
         leds.SetToParamStore();
         setup_store_to_EEPROM();
-#if defined(ESP8266) || defined(ESP32)
-        esp_setup(); //call reset
+        restart_controller = 1;
         return;
-#else
-        goto RESTARTCONTROLLER;
-#endif
     }
 
-#if defined(ESP8266) || defined(ESP32)
 }//end of loop
-#else
-  }//end of while(1) loop
-}//end of main
-#endif
 
-void setup(void) {esp_setup();};

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,9 +14,6 @@ src_dir = mLRS
 [env]
 framework = arduino
 monitor_speed = 115200
-monitor_port = COM24
-upload_port = COM24
-
 
 ;--------------------
 ; common environments
@@ -38,6 +35,8 @@ build_src_filter =
 
 [env_common_esp82xx]
 platform = espressif8266@4.2.1
+board_build.f_cpu = 160000000L
+build_type = release
 build_src_filter = ${env_common.build_src_filter}
 
 ;--------------------
@@ -47,8 +46,9 @@ build_src_filter = ${env_common.build_src_filter}
 [env:rx-devboard-900]
 extends = env_common_esp82xx
 board = nodemcuv2
-monitor_filters = esp8266_exception_decoder, default
+board_build.f_cpu = 80000000L
 build_type = debug
+monitor_filters = esp8266_exception_decoder, default
 build_src_filter = 
   ${env_common_esp82xx.build_src_filter} 
   +<modules/sx12xx-lib/src/sx127x.cpp>
@@ -59,8 +59,6 @@ build_flags =
 [env:rx-generic-900]
 extends = env_common_esp82xx
 board = esp8285
-board_build.f_cpu = 160000000L
-build_type = release
 build_src_filter = 
   ${env_common_esp82xx.build_src_filter} 
   +<modules/sx12xx-lib/src/sx127x.cpp>
@@ -70,8 +68,6 @@ build_flags =
 [env:rx-bayckrc-900-pa]
 extends = env_common_esp82xx
 board = esp8285
-board_build.f_cpu = 160000000L
-build_type = release
 build_src_filter = 
   ${env_common_esp82xx.build_src_filter} 
   +<modules/sx12xx-lib/src/sx127x.cpp>
@@ -80,9 +76,6 @@ build_flags =
 
 [env:rx-generic-2400]
 extends = env_common_esp82xx
-board = esp8285
-board_build.f_cpu = 160000000L
-build_type = release
 build_src_filter = 
   ${env_common_esp82xx.build_src_filter} 
   +<modules/sx12xx-lib/src/sx128x.cpp>
@@ -93,8 +86,6 @@ build_flags =
 [env:rx-generic-2400-pa]
 extends = env_common_esp82xx
 board = esp8285
-board_build.f_cpu = 160000000L
-build_type = release
 build_src_filter = 
   ${env_common_esp82xx.build_src_filter} 
   +<modules/sx12xx-lib/src/sx128x.cpp>
@@ -105,8 +96,6 @@ build_flags =
 [env:rx-generic-2400-pa-d]
 extends = env_common_esp82xx
 board = esp8285
-board_build.f_cpu = 160000000L
-build_type = release
 build_src_filter = 
   ${env_common_esp82xx.build_src_filter} 
   +<modules/sx12xx-lib/src/sx128x.cpp>

--- a/platformio.ini
+++ b/platformio.ini
@@ -67,6 +67,16 @@ build_src_filter =
 build_flags = 
   -DRX_GENERIC_900_ESP8285
 
+[env:rx-bayckrc-900-pa]
+extends = env_common_esp82xx
+board = esp8285
+board_build.f_cpu = 160000000L
+build_type = release
+build_src_filter = 
+  ${env_common_esp82xx.build_src_filter} 
+  +<modules/sx12xx-lib/src/sx127x.cpp>
+build_flags = 
+  -DRX_BAYCKRC_900_PA_ESP8285
 
 [env:rx-generic-2400]
 extends = env_common_esp82xx


### PR DESCRIPTION
Some more updates to progress the ESP8285 RX support.

- Removing an unneeded call to rxclock.disable_isr(), this is now handled by the global disable and enable of interrupts in the eeprom lib.

- Implementing setup and loop as per @olliw42 example, this should allow the mlrs-rx.cpp to run on both stm32 and esp(Arduino) without lots of macros.

